### PR TITLE
Basic Auth Flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@auth0/auth0-spa-js": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.5.0.tgz",
+      "integrity": "sha512-8yBQY+C+A+cr7zXKAHXYcm3gioJdUuP0Qb/RFShzh4Q2RGmBfdVkiOxt7oR2MJua3T1v5H53vZhQvTADvIcAIw==",
+      "requires": {
+        "browser-tabs-lock": "^1.1.9",
+        "core-js": "^3.2.1",
+        "es-cookie": "^1.2.0",
+        "fast-text-encoding": "^1.0.0",
+        "promise-polyfill": "^8.1.3",
+        "unfetch": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.0.tgz",
+          "integrity": "sha512-lQxb4HScV71YugF/X28LtePZj9AB7WqOpcB+YztYxusvhrgZiQXPmCYfPC5LHsw/+ScEtDbXU3xbqH3CjBRmYA=="
+        },
+        "promise-polyfill": {
+          "version": "8.1.3",
+          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+          "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -6254,6 +6279,11 @@
         }
       }
     },
+    "browser-tabs-lock": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.1.tgz",
+      "integrity": "sha512-3NFpbd8cBwXNvAxzmomvNze2nSi3y2Q3DtNxytAY7+olhm7V21qicKDY90A2LxuAUesQMQcSGm8uQgBy9P5lOA=="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -8810,6 +8840,11 @@
         "is-regex": "^1.0.4"
       }
     },
+    "es-cookie": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.0.tgz",
+      "integrity": "sha512-zwTwrryAbOlL2Ru+Id6irvwwrFPorqb8AHNL0dkU/u7XVwGN70qhAQoh+YIDtrk3150O//DwCA3DLgc7EjL/8g=="
+    },
     "es-to-primitive": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
@@ -10110,6 +10145,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
     },
     "fastq": {
       "version": "1.6.0",
@@ -26228,6 +26268,11 @@
         "curriable": "^1.2.4",
         "pathington": "^1.1.5"
       }
+    },
+    "unfetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "npm": "6.4.1"
   },
   "dependencies": {
+    "@auth0/auth0-spa-js": "^1.5.0",
     "@babel/runtime": "^7.0.0-beta.55",
     "@date-io/date-fns": "^1.3.9",
     "@material-ui/core": "^4.3.3",
@@ -44,16 +45,9 @@
     "format": "eslint --fix ."
   },
   "prettier": {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
     "singleQuote": true,
-    "trailingComma": "all",
-    "bracketSpacing": true,
-    "jsxBracketSameLine": false,
-    "arrowParens": "always",
-    "proseWrap": "preserve"
+    "bracketSpacing": false,
+    "trailingComma": "es5"
   },
   "eslintConfig": {
     "extends": [
@@ -64,11 +58,6 @@
   "eslintIgnore": [
     "build/"
   ],
-  "prettier": {
-    "singleQuote": true,
-    "bracketSpacing": false,
-    "trailingComma": "es5"
-  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900|Roboto&display=swap" rel="stylesheet">
     <style>
+      html {
+        background-color: hsl(216, 18%, 89%);
+      }
       a {
         color: inherit;
         text-decoration: none;

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import HomeIcon from '@material-ui/icons/Home';
 import ErrorBoundary from 'atoms/ErrorBoundary';
 import Resume from 'modules/Resume';
 import CreateResumePage from 'pages/CreateResumePage';
-import ProfilePage from 'pages/ProfilePage';
+import {ProfileAuth, ProfileStaff} from 'pages/ProfilePage';
 import theme from 'styles/theme';
 
 import {useAuth0} from 'lib/auth0';
@@ -65,8 +65,12 @@ const App = ({classes}) => {
               <Route exact path="/resume/:gdocId" component={Resume} />
               <Route exact path="/talent-home" component={TalentHome} />
 
-              <Route exact path="/profile/" component={ProfilePage} />
-              <Route exact path="/profile/:contactId" component={ProfilePage} />
+              <Route exact path="/profile/" component={ProfileAuth} />
+              <Route
+                exact
+                path="/profile/:contactId"
+                component={ProfileStaff}
+              />
 
               <Route
                 exact

--- a/src/App.js
+++ b/src/App.js
@@ -39,19 +39,13 @@ const App = ({classes}) => {
                     <HomeIcon />
                   </MenuItem>
                 </Link>
-                <Link to="/resume">
-                  <MenuItem>Generated Resume</MenuItem>
-                </Link>
-                <Link to="/create-resume">
-                  <MenuItem>Create Resume</MenuItem>
-                </Link>
                 <Link to="/contacts">
                   <MenuItem>Contacts</MenuItem>
                 </Link>
                 <div className={classes.grow} />
                 {!isAuthenticated && (
                   <Button color="inherit" onClick={() => loginWithRedirect({})}>
-                    Log in
+                    Log in / Sign up
                   </Button>
                 )}
                 {isAuthenticated && (
@@ -71,6 +65,7 @@ const App = ({classes}) => {
               <Route exact path="/resume/:gdocId" component={Resume} />
               <Route exact path="/talent-home" component={TalentHome} />
 
+              <Route exact path="/profile/" component={ProfilePage} />
               <Route exact path="/profile/:contactId" component={ProfilePage} />
 
               <Route

--- a/src/App.js
+++ b/src/App.js
@@ -2,16 +2,20 @@ import React from 'react';
 import {BrowserRouter as Router, Route, Switch, Link} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
-import Icon from '@material-ui/core/Icon';
+import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Toolbar from '@material-ui/core/Toolbar';
 import withStyles from '@material-ui/core/styles/withStyles';
+
+import HomeIcon from '@material-ui/icons/Home';
 
 import ErrorBoundary from 'atoms/ErrorBoundary';
 import Resume from 'modules/Resume';
 import CreateResumePage from 'pages/CreateResumePage';
 import ProfilePage from 'pages/ProfilePage';
 import theme from 'styles/theme';
+
+import {useAuth0} from 'lib/auth0';
 
 /* TODO remove these or move to pages folder */
 import Home from 'components/Other/Home.js';
@@ -20,69 +24,87 @@ import SearchContact from 'components/SearchContact/SearchContact';
 import ResumeTemplate from 'components/Other/ResumeTemplate';
 import TalentHome from 'components/TalentHome/TalentHome';
 
-const App = ({classes}) => (
-  <ErrorBoundary fileName="src/App.js">
-    <MuiThemeProvider theme={theme}>
-      <Router>
-        <div className={classes.page}>
-          <AppBar position="fixed">
-            <Toolbar>
-              <Link to="/">
-                <MenuItem>
-                  <Icon>home</Icon>
-                </MenuItem>
-              </Link>
-              <Link to="/resume">
-                <MenuItem>Generated Resume</MenuItem>
-              </Link>
-              <Link to="/create-resume">
-                <MenuItem>Create Resume</MenuItem>
-              </Link>
-              <Link to="/contacts">
-                <MenuItem>Contacts</MenuItem>
-              </Link>
-            </Toolbar>
-          </AppBar>
-          <Toolbar /> {/* for automatic padding of AppBar */}
-          <Switch>
-            <Route exact path="/" component={Home} />
+const App = ({classes}) => {
+  const {isAuthenticated, loginWithRedirect, logout} = useAuth0();
 
-            <Route exact path="/contacts" component={Contacts} />
-            <Route exact path="/search-contact" component={SearchContact} />
+  return (
+    <ErrorBoundary fileName="src/App.js">
+      <MuiThemeProvider theme={theme}>
+        <Router>
+          <div className={classes.page}>
+            <AppBar position="fixed">
+              <Toolbar>
+                <Link to="/">
+                  <MenuItem>
+                    <HomeIcon />
+                  </MenuItem>
+                </Link>
+                <Link to="/resume">
+                  <MenuItem>Generated Resume</MenuItem>
+                </Link>
+                <Link to="/create-resume">
+                  <MenuItem>Create Resume</MenuItem>
+                </Link>
+                <Link to="/contacts">
+                  <MenuItem>Contacts</MenuItem>
+                </Link>
+                <div className={classes.grow} />
+                {!isAuthenticated && (
+                  <Button color="inherit" onClick={() => loginWithRedirect({})}>
+                    Log in
+                  </Button>
+                )}
+                {isAuthenticated && (
+                  <Button color="inherit" onClick={() => logout()}>
+                    Log out
+                  </Button>
+                )}
+              </Toolbar>
+            </AppBar>
+            <Toolbar /> {/* for automatic padding of AppBar */}
+            <Switch>
+              <Route exact path="/" component={Home} />
 
-            <Route exact path="/resume/:gdocId" component={Resume} />
-            <Route exact path="/talent-home" component={TalentHome} />
+              <Route exact path="/contacts" component={Contacts} />
+              <Route exact path="/search-contact" component={SearchContact} />
 
-            <Route exact path="/profile/:contactId" component={ProfilePage} />
+              <Route exact path="/resume/:gdocId" component={Resume} />
+              <Route exact path="/talent-home" component={TalentHome} />
 
-            <Route
-              exact
-              path="/profile/:contactId/resume/:resumeId"
-              component={Resume}
-            />
-            <Route
-              exact
-              path="/contacts/:contactId/resume/:resumeId"
-              component={Resume}
-            />
-            <Route
-              exact
-              path="/contacts/:contactId/create-resume"
-              component={CreateResumePage}
-            />
-            <Route
-              exact
-              path="/contacts/:contactId/create-resume/:resumeId"
-              component={CreateResumePage}
-            />
-          </Switch>
-        </div>
-      </Router>
-    </MuiThemeProvider>
-  </ErrorBoundary>
-);
+              <Route exact path="/profile/:contactId" component={ProfilePage} />
+
+              <Route
+                exact
+                path="/profile/:contactId/resume/:resumeId"
+                component={Resume}
+              />
+              <Route
+                exact
+                path="/contacts/:contactId/resume/:resumeId"
+                component={Resume}
+              />
+              <Route
+                exact
+                path="/contacts/:contactId/create-resume"
+                component={CreateResumePage}
+              />
+              <Route
+                exact
+                path="/contacts/:contactId/create-resume/:resumeId"
+                component={CreateResumePage}
+              />
+            </Switch>
+          </div>
+        </Router>
+      </MuiThemeProvider>
+    </ErrorBoundary>
+  );
+};
 
 const styles = ({breakpoints, palette, spacing}) => ({
+  grow: {
+    flexGrow: 1,
+  },
   page: {
     backgroundColor: 'hsl(216, 18%, 89%)',
     paddingBottom: spacing(5),

--- a/src/actions/contacts.js
+++ b/src/actions/contacts.js
@@ -1,5 +1,6 @@
 import {API_URL} from '../constants';
 import {makeFetchActions, fetchActionTypes} from 'redux-fetch-wrapper';
+import {makeAuthFetchActions} from 'lib/auth0';
 
 // ## API ACTION CREATORS ##
 // Note on naming convention here:
@@ -36,3 +37,21 @@ const addContactLocal = contact => ({
   type: ADD_CONTACT,
   contact,
 });
+
+export const GET_MY_CONTACT = 'GET_MY_CONTACT';
+export const GET_MY_CONTACT_API = fetchActionTypes(GET_MY_CONTACT);
+export const getMyContact = authToken =>
+  async function(dispatch) {
+    dispatch({
+      type: GET_MY_CONTACT,
+    });
+
+    await apiGetMyContact(authToken)(dispatch);
+  };
+
+const apiGetMyContact = authToken =>
+  makeAuthFetchActions(
+    authToken,
+    GET_MY_CONTACT,
+    `${API_URL}/api/contacts/me/`
+  );

--- a/src/actions/contacts.js
+++ b/src/actions/contacts.js
@@ -30,7 +30,7 @@ export const addContact = contact =>
   async function(dispatch) {
     dispatch(addContactLocal(contact));
 
-    await apiAddContact(contact)(dispatch);
+    return await apiAddContact(contact)(dispatch);
   };
 
 const addContactLocal = contact => ({
@@ -46,7 +46,7 @@ export const getMyContact = authToken =>
       type: GET_MY_CONTACT,
     });
 
-    await apiGetMyContact(authToken)(dispatch);
+    return await apiGetMyContact(authToken)(dispatch);
   };
 
 const apiGetMyContact = authToken =>

--- a/src/actions/contacts.spec.js
+++ b/src/actions/contacts.spec.js
@@ -1,5 +1,12 @@
 import fetchMock from 'fetch-mock';
-import {ADD_CONTACT, ADD_CONTACT_API, addContact} from './contacts';
+import {
+  GET_MY_CONTACT,
+  GET_MY_CONTACT_API,
+  getMyContact,
+  ADD_CONTACT,
+  ADD_CONTACT_API,
+  addContact,
+} from './contacts';
 
 afterEach(() => {
   fetchMock.restore();
@@ -40,4 +47,31 @@ test('Create new contact action - failure', async function() {
   expect(dispatch.mock.calls.length).toBe(3);
   expect(dispatch.mock.calls[2][0].type).toBe(ADD_CONTACT_API.REJECT);
   expect(dispatch.mock.calls[2][0].statusCode).toBe(500);
+});
+
+test('Get my contact', async function() {
+  const dispatch = jest.fn();
+  const token = 'testAuthToken';
+  const response = {contact: 'me'};
+
+  fetchMock.get(
+    `path:/api/contacts/me/`,
+    {
+      status: 200,
+      body: response,
+    },
+    {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  await getMyContact(token)(dispatch);
+
+  expect(dispatch.mock.calls.length).toBe(3);
+  expect(dispatch.mock.calls[0][0].type).toBe(GET_MY_CONTACT);
+  expect(dispatch.mock.calls[1][0].type).toBe(GET_MY_CONTACT_API.REQUEST);
+  expect(dispatch.mock.calls[2][0].type).toBe(GET_MY_CONTACT_API.RESOLVE);
+  expect(dispatch.mock.calls[2][0].body).toEqual(response);
 });

--- a/src/authConfig.json
+++ b/src/authConfig.json
@@ -1,0 +1,4 @@
+{
+  "domain": "baltimore-corps.auth0.com",
+  "clientId": "8MxKwe0gLeBfywJImXY89s5FPntBcy4N"
+}

--- a/src/components/Contacts/AddContact.js
+++ b/src/components/Contacts/AddContact.js
@@ -42,12 +42,19 @@ import {newProfileValidator} from '../../lib/formValidator';
 //   },
 // ];
 
-const useForm = (addNewContact, accountId) => {
-  const [values, setValues] = useState({});
+const useForm = (addNewContact, accountId, emailSuggest) => {
+  const initValues = {};
+  if (accountId) {
+    initValues.account_id = accountId;
+  }
+  if (emailSuggest) {
+    initValues.email = emailSuggest;
+  }
+
+  const [values, setValues] = useState(initValues);
 
   const handleSubmit = () => {
     let submission = Object.assign({}, values);
-    submission.account_id = accountId || null;
     submission.email_primary = {
       is_primary: true,
       email: values.email,
@@ -67,11 +74,18 @@ const useForm = (addNewContact, accountId) => {
   return [values, handleChange, handleSubmit];
 };
 
-const AddContact = ({classes, addNewContact, dialog, accountId}) => {
+const AddContact = ({
+  classes,
+  addNewContact,
+  dialog,
+  accountId,
+  emailSuggest,
+}) => {
   const [open, setOpen] = useState(false);
   const [values, handleChange, handleSubmit] = useForm(
     addNewContact,
-    accountId
+    accountId,
+    emailSuggest
   );
   const [errors, setErrors] = useState({});
 
@@ -238,7 +252,8 @@ AddContact.propTypes = {
   classes: PropTypes.object.isRequired,
   addNewContact: PropTypes.func.isRequired,
   dialog: PropTypes.bool,
-  userId: PropTypes.string,
+  accountId: PropTypes.string,
+  emailSuggest: PropTypes.string,
 };
 
 const styles = ({breakpoints, palette, spacing}) => ({

--- a/src/components/Contacts/AddContact.js
+++ b/src/components/Contacts/AddContact.js
@@ -7,6 +7,8 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
 import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -40,11 +42,12 @@ import {newProfileValidator} from '../../lib/formValidator';
 //   },
 // ];
 
-const useForm = addNewContact => {
+const useForm = (addNewContact, accountId) => {
   const [values, setValues] = useState({});
 
   const handleSubmit = () => {
     let submission = Object.assign({}, values);
+    submission.account_id = accountId || null;
     submission.email_primary = {
       is_primary: true,
       email: values.email,
@@ -64,9 +67,12 @@ const useForm = addNewContact => {
   return [values, handleChange, handleSubmit];
 };
 
-const AddContact = ({classes, addNewContact}) => {
+const AddContact = ({classes, addNewContact, dialog, accountId}) => {
   const [open, setOpen] = useState(false);
-  const [values, handleChange, handleSubmit] = useForm(addNewContact);
+  const [values, handleChange, handleSubmit] = useForm(
+    addNewContact,
+    accountId
+  );
   const [errors, setErrors] = useState({});
 
   const submit = () => {
@@ -94,114 +100,145 @@ const AddContact = ({classes, addNewContact}) => {
     values.phone_primary = value;
   };
 
-  return (
-    <React.Fragment>
-      <Button
-        variant="contained"
-        color="primary"
-        className={classes.button}
-        onClick={() => setOpen(true)}
-        style={{fontWeight: 700}}
-      >
-        New Profile
-      </Button>
-      <Dialog
-        open={open}
-        onClose={() => setOpen(false)}
-        aria-labelledby="form-dialog-title"
-      >
-        <DialogTitle id="form-dialog-title" className={classes.header}>
-          <span style={{fontWeight: 700}}>Add New Profile</span>
-        </DialogTitle>
-
-        <DialogContent className={classes.container}>
-          <form noValidate autoComplete="off">
-            <Grid container direction="column">
-              <TextField
-                required
-                id="first-name"
-                label="First Name"
-                className={classes.textField}
-                name="first_name"
-                value={values.first_name || ''}
-                onChange={handleChange}
-                InputLabelProps={inputLabelProps}
-                InputProps={inputProps}
-              />
-              <FormHelperText className={classes.formHelperText}>
-                {errors.firstName_error || null}
-              </FormHelperText>
-              <TextField
-                required
-                id="last-name"
-                label="Last Name"
-                className={classes.textField}
-                name="last_name"
-                value={values.last_name || ''}
-                onChange={handleChange}
-                InputLabelProps={inputLabelProps}
-                InputProps={inputProps}
-              />
-              <FormHelperText className={classes.formHelperText}>
-                {errors.lastName_error || null}
-              </FormHelperText>
-              <TextField
-                required
-                id="email"
-                label="Primary Email"
-                name="email"
-                value={values.email || ''}
-                onChange={handleChange}
-                className={classes.textField}
-                InputLabelProps={inputLabelProps}
-                InputProps={inputProps}
-              />
-              <FormHelperText className={classes.formHelperText}>
-                {errors.email_error || null}
-              </FormHelperText>
-              <MuiPhoneNumber
-                name="phone_primary"
-                label="Primary Phone"
-                defaultCountry={'us'}
-                value={values.phone_primary}
-                onChange={handlePhoneInput}
-                InputLabelProps={inputLabelProps}
-                InputProps={inputProps}
-                className={classes.textField}
-                disableAreaCodes={true}
-              />
-              <FormHelperText className={classes.formHelperText}>
-                {errors.phonePrimary_error || null}
-              </FormHelperText>
-            </Grid>
-          </form>
-        </DialogContent>
-
-        <DialogActions className={classes.actions}>
-          <Button
-            onClick={submit}
-            variant="contained"
-            color="primary"
-            style={{fontWeight: 600}}
-          >
-            Create Profile
-          </Button>
-          <Button
-            onClick={() => setOpen(false)}
-            color="primary"
-            style={{fontWeight: 600}}
-          >
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </React.Fragment>
+  // It's kind of gross to have this component have two different forms
+  // it renders in, but the <DialogActions> element makes this difficult to
+  // factor out
+  const form = (
+    <form noValidate autoComplete="off">
+      <Grid container direction="column">
+        <TextField
+          required
+          id="first-name"
+          label="First Name"
+          className={classes.textField}
+          name="first_name"
+          value={values.first_name || ''}
+          onChange={handleChange}
+          InputLabelProps={inputLabelProps}
+          InputProps={inputProps}
+        />
+        <FormHelperText className={classes.formHelperText}>
+          {errors.firstName_error || null}
+        </FormHelperText>
+        <TextField
+          required
+          id="last-name"
+          label="Last Name"
+          className={classes.textField}
+          name="last_name"
+          value={values.last_name || ''}
+          onChange={handleChange}
+          InputLabelProps={inputLabelProps}
+          InputProps={inputProps}
+        />
+        <FormHelperText className={classes.formHelperText}>
+          {errors.lastName_error || null}
+        </FormHelperText>
+        <TextField
+          required
+          id="email"
+          label="Primary Email"
+          name="email"
+          value={values.email || ''}
+          onChange={handleChange}
+          className={classes.textField}
+          InputLabelProps={inputLabelProps}
+          InputProps={inputProps}
+        />
+        <FormHelperText className={classes.formHelperText}>
+          {errors.email_error || null}
+        </FormHelperText>
+        <MuiPhoneNumber
+          name="phone_primary"
+          label="Primary Phone"
+          defaultCountry={'us'}
+          value={values.phone_primary}
+          onChange={handlePhoneInput}
+          InputLabelProps={inputLabelProps}
+          InputProps={inputProps}
+          className={classes.textField}
+          disableAreaCodes={true}
+        />
+        <FormHelperText className={classes.formHelperText}>
+          {errors.phonePrimary_error || null}
+        </FormHelperText>
+      </Grid>
+    </form>
   );
+
+  if (dialog) {
+    return (
+      <React.Fragment>
+        <Button
+          variant="contained"
+          color="primary"
+          className={classes.button}
+          onClick={() => setOpen(true)}
+          style={{fontWeight: 700}}
+        >
+          New Profile
+        </Button>
+        <Dialog
+          open={open}
+          onClose={() => setOpen(false)}
+          aria-labelledby="form-dialog-title"
+        >
+          <DialogTitle id="form-dialog-title" className={classes.header}>
+            <span style={{fontWeight: 700}}>Add New Profile</span>
+          </DialogTitle>
+
+          <DialogContent className={classes.container}>{form}</DialogContent>
+
+          <DialogActions className={classes.actions}>
+            <Button
+              onClick={submit}
+              variant="contained"
+              color="primary"
+              style={{fontWeight: 600}}
+            >
+              Create Profile
+            </Button>
+            <Button
+              onClick={() => setOpen(false)}
+              color="primary"
+              style={{fontWeight: 600}}
+            >
+              Cancel
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </React.Fragment>
+    );
+  } else {
+    return (
+      <Paper className={classes.paper}>
+        <Typography
+          component="h1"
+          variant="h5"
+          align="left"
+          className={classes.paperHeader}
+        >
+          Profile Basics
+        </Typography>
+        {form}
+        <Button
+          onClick={submit}
+          variant="contained"
+          color="primary"
+          className={classes.createButton}
+        >
+          Create Profile
+        </Button>
+      </Paper>
+    );
+  }
 };
 
 AddContact.propTypes = {
   classes: PropTypes.object.isRequired,
   addNewContact: PropTypes.func.isRequired,
+  dialog: PropTypes.bool,
+  userId: PropTypes.string,
 };
 
 const styles = ({breakpoints, palette, spacing}) => ({
@@ -231,6 +268,22 @@ const styles = ({breakpoints, palette, spacing}) => ({
     color: palette.error.main,
     marginTop: '2px',
     marginBottom: '4px',
+  },
+  paper: {
+    padding: spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    [breakpoints.up('sm')]: {
+      minWidth: '400px',
+    },
+  },
+  paperHeader: {
+    margin: spacing(0, 0, 2),
+  },
+  createButton: {
+    fontWeight: 600,
+    margin: spacing(2, 0, 0, 0),
   },
 });
 

--- a/src/components/Contacts/Contacts.js
+++ b/src/components/Contacts/Contacts.js
@@ -19,7 +19,7 @@ const Contacts = props => {
             contacts={props.contacts}
             refreshContacts={props.refreshContacts}
           />
-          <AddContact addNewContact={props.addNewContact} />
+          <AddContact addNewContact={props.addNewContact} dialog />
         </React.Fragment>
       </Paper>
     </main>

--- a/src/components/Other/Home.js
+++ b/src/components/Other/Home.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
+import {Redirect} from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
@@ -8,38 +8,48 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
+import {useAuth0} from 'lib/auth0';
+
 const Home = () => {
+  const {isAuthenticated, loginWithRedirect} = useAuth0();
+
+  if (isAuthenticated) {
+    return <Redirect to="/profile" />;
+  }
+
   return (
     <Grid container justify="center">
       <Grid item xs={10}>
         <Typography gutterBottom variant="h3" component="h1">
           Baltimore Corps Talent Matching
         </Typography>
-        <Grid container justify="space-between" spacing={3}>
+        <Grid container justify="center" spacing={3}>
           {Home.cardDetails.map(({header, description, imageName, url}) => (
             <Grid item key={header} xs={3}>
-              <Link to={url}>
-                <Card>
-                  <CardMedia
-                    component="img"
-                    height="140"
-                    image={`/images/${imageName}.jpeg`}
-                  />
-                  <CardContent>
-                    <Typography gutterBottom variant="h5" component="h2">
-                      {header}
-                    </Typography>
-                    <Typography gutterBottom variant="body1" component="p">
-                      {description}
-                    </Typography>
-                  </CardContent>
-                  <CardActions>
-                    <Button variant="contained" color="primary">
-                      Log in / Sign up
-                    </Button>
-                  </CardActions>
-                </Card>
-              </Link>
+              <Card>
+                <CardMedia
+                  component="img"
+                  height="140"
+                  image={`/images/${imageName}.jpeg`}
+                />
+                <CardContent>
+                  <Typography gutterBottom variant="h5" component="h2">
+                    {header}
+                  </Typography>
+                  <Typography gutterBottom variant="body1" component="p">
+                    {description}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={() => loginWithRedirect({})}
+                  >
+                    Log in / Sign up
+                  </Button>
+                </CardActions>
+              </Card>
             </Grid>
           ))}
         </Grid>
@@ -50,25 +60,10 @@ const Home = () => {
 
 Home.cardDetails = [
   {
-    header: 'Talent',
+    header: 'Sign up or log in',
     description:
-      'Join as a talent, you can find numerous positions/opportunities in NGO here.',
+      'Create an account or log in to create a Baltimore Corps community profile.\nGet access to job opportunities and development opportunities in the Baltimore Corps network',
     imageName: 'talent',
-    url: '/contacts',
-  },
-  {
-    header: 'Organization',
-    description:
-      'Join as an organization, you can find numerous talents for your organization.',
-    imageName: 'organization',
-    url: '/contacts',
-  },
-  {
-    header: 'Baltimore Corps Staff',
-    description:
-      'As a Baltimore Staff, you can access data stored in database.',
-    imageName: 'baltimoreCorpsStaff',
-    url: '/contacts',
   },
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import {Provider} from 'react-redux';
 import {configureStore} from 'redux-starter-kit';
 import rootReducer from './reducers';
 import App from './App';
+import {Auth0Provider} from './lib/auth0';
+import config from './authConfig.json';
 
 import * as serviceWorker from './serviceWorker';
 
@@ -11,9 +13,30 @@ const store = configureStore({
   reducer: rootReducer,
 });
 
+// A function that routes the user to the right place
+// after login
+//
+// See: https://auth0.com/docs/quickstart/spa/react
+const onRedirectCallback = appState => {
+  window.history.replaceState(
+    {},
+    document.title,
+    appState && appState.targetUrl
+      ? appState.targetUrl
+      : window.location.pathname
+  );
+};
+
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <Auth0Provider
+      domain={config.domain}
+      client_id={config.clientId}
+      redirect_uri={window.location.origin}
+      onRedirectCallback={onRedirectCallback}
+    >
+      <App />
+    </Auth0Provider>
   </Provider>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ ReactDOM.render(
       domain={config.domain}
       client_id={config.clientId}
       redirect_uri={window.location.origin}
+      audience={'http://localhost:5000'}
       onRedirectCallback={onRedirectCallback}
     >
       <App />

--- a/src/lib/auth0.js
+++ b/src/lib/auth0.js
@@ -1,0 +1,89 @@
+// Utilities for using Auth0
+// From https://auth0.com/docs/quickstart/spa/react
+
+import React, {useState, useEffect, useContext} from 'react';
+import createAuth0Client from '@auth0/auth0-spa-js';
+
+const DEFAULT_REDIRECT_CALLBACK = () =>
+  window.history.replaceState({}, document.title, window.location.pathname);
+
+export const Auth0Context = React.createContext();
+export const useAuth0 = () => useContext(Auth0Context);
+export const Auth0Provider = ({
+  children,
+  onRedirectCallback = DEFAULT_REDIRECT_CALLBACK,
+  ...initOptions
+}) => {
+  const [isAuthenticated, setIsAuthenticated] = useState();
+  const [user, setUser] = useState();
+  const [auth0Client, setAuth0] = useState();
+  const [loading, setLoading] = useState(true);
+  const [popupOpen, setPopupOpen] = useState(false);
+
+  useEffect(() => {
+    const initAuth0 = async () => {
+      const auth0FromHook = await createAuth0Client(initOptions);
+      setAuth0(auth0FromHook);
+
+      if (window.location.search.includes('code=')) {
+        const {appState} = await auth0FromHook.handleRedirectCallback();
+        onRedirectCallback(appState);
+      }
+
+      const isAuthenticated = await auth0FromHook.isAuthenticated();
+
+      setIsAuthenticated(isAuthenticated);
+
+      if (isAuthenticated) {
+        const user = await auth0FromHook.getUser();
+        setUser(user);
+      }
+
+      setLoading(false);
+    };
+    initAuth0();
+    // eslint-disable-next-line
+  }, []);
+
+  const loginWithPopup = async (params = {}) => {
+    setPopupOpen(true);
+    try {
+      await auth0Client.loginWithPopup(params);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setPopupOpen(false);
+    }
+    const user = await auth0Client.getUser();
+    setUser(user);
+    setIsAuthenticated(true);
+  };
+
+  const handleRedirectCallback = async () => {
+    setLoading(true);
+    await auth0Client.handleRedirectCallback();
+    const user = await auth0Client.getUser();
+    setLoading(false);
+    setIsAuthenticated(true);
+    setUser(user);
+  };
+  return (
+    <Auth0Context.Provider
+      value={{
+        isAuthenticated,
+        user,
+        loading,
+        popupOpen,
+        loginWithPopup,
+        handleRedirectCallback,
+        getIdTokenClaims: (...p) => auth0Client.getIdTokenClaims(...p),
+        loginWithRedirect: (...p) => auth0Client.loginWithRedirect(...p),
+        getTokenSilently: (...p) => auth0Client.getTokenSilently(...p),
+        getTokenWithPopup: (...p) => auth0Client.getTokenWithPopup(...p),
+        logout: (...p) => auth0Client.logout(...p),
+      }}
+    >
+      {children}
+    </Auth0Context.Provider>
+  );
+};

--- a/src/lib/auth0.js
+++ b/src/lib/auth0.js
@@ -3,9 +3,34 @@
 
 import React, {useState, useEffect, useContext} from 'react';
 import createAuth0Client from '@auth0/auth0-spa-js';
+import {makeFetchActions} from 'redux-fetch-wrapper';
 
 const DEFAULT_REDIRECT_CALLBACK = () =>
   window.history.replaceState({}, document.title, window.location.pathname);
+
+export const makeAuthFetchActions = (
+  token,
+  action,
+  url,
+  init = null,
+  actions = null,
+  abortController = null,
+  conditional = null
+) => {
+  if (init === null) {
+    init = {headers: {}};
+  }
+
+  init.headers['Authorization'] = `Bearer ${token}`;
+  return makeFetchActions(
+    action,
+    url,
+    init,
+    actions,
+    abortController,
+    conditional
+  );
+};
 
 export const Auth0Context = React.createContext();
 export const useAuth0 = () => useContext(Auth0Context);

--- a/src/pages/ProfilePage/Profile.container.js
+++ b/src/pages/ProfilePage/Profile.container.js
@@ -1,0 +1,17 @@
+import {connect} from 'react-redux';
+import {addContact, getMyContact} from 'actions/contacts';
+import Profile from './Profile';
+
+export const mapStateToProps = (state, props) => ({accounts: state.accounts});
+
+export const mapDispatchToProps = dispatch => ({
+  addContact: contact => addContact(contact)(dispatch),
+  getMyContact: authToken => getMyContact(authToken)(dispatch),
+});
+
+const ProfileContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Profile);
+
+export default ProfileContainer;

--- a/src/pages/ProfilePage/Profile.js
+++ b/src/pages/ProfilePage/Profile.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {useAuth0} from 'lib/auth0';
 import Grid from '@material-ui/core/Grid';
@@ -6,28 +6,56 @@ import Grid from '@material-ui/core/Grid';
 import AddContact from '../../components/Contacts/AddContact';
 import ProfilePage from './ProfilePage.container';
 
-const Profile = ({accounts, addContact, getMyContact}) => {
-  const {getTokenSilently, loading, user} = useAuth0();
+const LOADING_STATE = {
+  notLoaded: 0,
+  loading: 1,
+  loaded: 2,
+};
 
+const Profile = ({accounts, addContact, getMyContact}) => {
+  const {getTokenSilently, loadingAuth, user} = useAuth0();
+  const [loadingState, setLoadingState] = useState(LOADING_STATE.notLoaded);
+
+  // Loads contact associated with our account (requires us to be AuthN'd)
   const getAccountContact = async () => {
     try {
+      // Don't load a bunch of times in a row
+      if (loadingState === LOADING_STATE.loading) {
+        return;
+      }
+
+      // getTokenSilently will fail if we're not authenticated already
+      if (!user) {
+        return;
+      }
+
+      setLoadingState(LOADING_STATE.loading);
       const token = await getTokenSilently();
-      await getMyContact(token);
+      const result = await getMyContact(token);
+      console.log(result);
+      setLoadingState(LOADING_STATE.loaded);
     } catch (error) {
+      setLoadingState(LOADING_STATE.notLoaded);
       console.error(error);
     }
   };
 
+  // If we haven't started loading the contact yet, do so
+  if (loadingState === LOADING_STATE.notLoaded) {
+    getAccountContact();
+  }
+
   // Show this page if we're not yet authenticated
-  if (loading || !user) {
+  if (!loadingAuth && !user) {
+    return <div>You are not logged in.</div>;
+  }
+  if (loadingState !== LOADING_STATE.loaded) {
     return <div>Loading...</div>;
   }
 
   let contactId = null;
   if (user.sub in accounts) {
     contactId = accounts[user.sub].id;
-  } else {
-    getAccountContact();
   }
 
   if (!contactId) {
@@ -45,7 +73,7 @@ const Profile = ({accounts, addContact, getMyContact}) => {
   }
 };
 
-ProfilePage.propTypes = {
+Profile.propTypes = {
   accounts: PropTypes.object.isRequired,
   addContact: PropTypes.func.isRequired,
   getMyContact: PropTypes.func.isRequired,

--- a/src/pages/ProfilePage/Profile.js
+++ b/src/pages/ProfilePage/Profile.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useAuth0} from 'lib/auth0';
+import Grid from '@material-ui/core/Grid';
+
+import AddContact from '../../components/Contacts/AddContact';
+import ProfilePage from './ProfilePage.container';
+
+const Profile = ({accounts, addContact, getMyContact}) => {
+  const {getTokenSilently, loading, user} = useAuth0();
+
+  const getAccountContact = async () => {
+    try {
+      const token = await getTokenSilently();
+      await getMyContact(token);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // Show this page if we're not yet authenticated
+  if (loading || !user) {
+    return <div>Loading...</div>;
+  }
+
+  let contactId = null;
+  if (user.sub in accounts) {
+    contactId = accounts[user.sub].id;
+  } else {
+    getAccountContact();
+  }
+
+  if (!contactId) {
+    return (
+      <Grid xs={12} container justify="center">
+        <AddContact addNewContact={addContact} accountId={user.sub} />
+      </Grid>
+    );
+  } else {
+    return <ProfilePage contactId={contactId} />;
+  }
+};
+
+ProfilePage.propTypes = {
+  accounts: PropTypes.object.isRequired,
+  addContact: PropTypes.func.isRequired,
+  getMyContact: PropTypes.func.isRequired,
+};
+
+export default Profile;

--- a/src/pages/ProfilePage/Profile.js
+++ b/src/pages/ProfilePage/Profile.js
@@ -33,7 +33,11 @@ const Profile = ({accounts, addContact, getMyContact}) => {
   if (!contactId) {
     return (
       <Grid xs={12} container justify="center">
-        <AddContact addNewContact={addContact} accountId={user.sub} />
+        <AddContact
+          addNewContact={addContact}
+          accountId={user.sub}
+          emailSuggest={user.email}
+        />
       </Grid>
     );
   } else {

--- a/src/pages/ProfilePage/ProfilePage.container.js
+++ b/src/pages/ProfilePage/ProfilePage.container.js
@@ -25,7 +25,8 @@ const getExperiences = createSelector(
 const getSelection = createSelector(['resume.selected']);
 const getResumeCreationStep = createSelector(['resume.resumeCreationStep']);
 
-const getContact = (state, props) => props.match.params.contactId;
+const getContact = (state, props) =>
+  props.contactId || props.match.params.contactId;
 
 const getResumeAll = createSelector(
   [getExperiences, getSelection, getContact],
@@ -123,7 +124,7 @@ const getResume = createSelector(
 // The props to this container specify which particular contact we want to
 // display on the page, and we pull that contact's info out of the state
 export const mapStateToProps = (state, props) => {
-  const contactId = props.match.params.contactId;
+  const contactId = props.contactId || props.match.params.contactId;
   const contactInfo = state.contacts[contactId];
   return {
     contactId: Number(contactId),

--- a/src/pages/ProfilePage/ProfilePage.js
+++ b/src/pages/ProfilePage/ProfilePage.js
@@ -68,7 +68,8 @@ const ProfilePage = ({
   // that state from the API. If this load goes well, this page should be
   // rerendered due to the Redux state update
   if (typeof contactInfo === 'undefined') {
-    refreshContacts();
+    console.log(contactId);
+    //refreshContacts();
     // TODO: Ideally we have a better empty/error state here
     return <div />;
   }

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -1,3 +1,7 @@
 import Profile from './Profile.container';
+import ProfilePage from './ProfilePage.container';
 
-export default Profile;
+export const ProfileAuth = Profile;
+export const ProfileStaff = ProfilePage;
+
+export default ProfileAuth;

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -1,3 +1,3 @@
-import ProfilePage from './ProfilePage.container';
+import Profile from './Profile.container';
 
-export default ProfilePage;
+export default Profile;

--- a/src/reducers/contacts.js
+++ b/src/reducers/contacts.js
@@ -1,7 +1,11 @@
 import {createReducer} from 'redux-starter-kit';
 
 /* eslint-disable no-unused-vars */
-import {ALL_CONTACTS, ALL_CONTACTS_API} from '../actions/contacts';
+import {
+  ALL_CONTACTS,
+  ALL_CONTACTS_API,
+  GET_MY_CONTACT_API,
+} from '../actions/contacts';
 import {CREATE_RESUME, CREATE_RESUME_API} from 'actions/resume';
 /* eslint-enable no-unused-vars */
 
@@ -19,19 +23,33 @@ export const contactsReducer = createReducer(
         return newState;
       }
     },
-    [CREATE_RESUME_API.RESOLVE]: (state, action) => {
-      if (!action.body) {
-        return {};
-      }
-      const {data} = action.body;
-      return {
-        ...state,
-        [data.contact.id]: {
-          ...data.contact,
-        },
-      };
+    [GET_MY_CONTACT_API.RESOLVE]: (state, action) => {
+      const contact = action.body.data;
+      state[contact.id] = contact;
     },
   }
 );
 
-export default contactsReducer;
+export const accountsReducer = createReducer(
+  {},
+  {
+    [ALL_CONTACTS_API.RESOLVE]: (state, action) => {
+      if (!action.body) {
+        return {};
+      } else {
+        let newState = {};
+        action.body.data.forEach(contact => {
+          if (!contact.account_id) {
+            return;
+          }
+          newState[contact.account_id] = contact;
+        });
+        return newState;
+      }
+    },
+    [GET_MY_CONTACT_API.RESOLVE]: (state, action) => {
+      const contact = action.body.data;
+      state[contact.account_id] = contact;
+    },
+  }
+);

--- a/src/reducers/contacts.js
+++ b/src/reducers/contacts.js
@@ -4,6 +4,7 @@ import {createReducer} from 'redux-starter-kit';
 import {
   ALL_CONTACTS,
   ALL_CONTACTS_API,
+  ADD_CONTACT_API,
   GET_MY_CONTACT_API,
 } from '../actions/contacts';
 import {CREATE_RESUME, CREATE_RESUME_API} from 'actions/resume';
@@ -24,6 +25,10 @@ export const contactsReducer = createReducer(
       }
     },
     [GET_MY_CONTACT_API.RESOLVE]: (state, action) => {
+      const contact = action.body.data;
+      state[contact.id] = contact;
+    },
+    [ADD_CONTACT_API.RESOLVE]: (state, action) => {
       const contact = action.body.data;
       state[contact.id] = contact;
     },
@@ -50,6 +55,12 @@ export const accountsReducer = createReducer(
     [GET_MY_CONTACT_API.RESOLVE]: (state, action) => {
       const contact = action.body.data;
       state[contact.account_id] = contact;
+    },
+    [ADD_CONTACT_API.RESOLVE]: (state, action) => {
+      const contact = action.body.data;
+      if (contact.account_id) {
+        state[contact.account_id] = contact;
+      }
     },
   }
 );

--- a/src/reducers/contacts.spec.js
+++ b/src/reducers/contacts.spec.js
@@ -3,6 +3,7 @@ import {contactsReducer, accountsReducer} from './contacts';
 import {
   ALL_CONTACTS,
   ALL_CONTACTS_API,
+  ADD_CONTACT_API,
   GET_MY_CONTACT_API,
 } from '../actions/contacts';
 import {CREATE_RESUME_API} from '../actions/resume';
@@ -24,6 +25,16 @@ describe('Contacts state', () => {
       2: {id: 2},
       3: {id: 3},
       4: {id: 4},
+    });
+  });
+  test('Add contact', () => {
+    const contact = {id: 123};
+    const newState = contactsReducer(undefined, {
+      type: ADD_CONTACT_API.RESOLVE,
+      body: {status: 'success', data: contact},
+    });
+    expect(newState).toEqual({
+      123: {id: 123},
     });
   });
   test('Get my contact', () => {
@@ -62,6 +73,25 @@ describe('accounts state', () => {
     const newState = accountsReducer(undefined, {});
     expect(newState).toEqual(initialState);
   });
+  test('Add contact', () => {
+    const contact = {id: 123, account_id: 'auth|123'};
+    const newState = accountsReducer(undefined, {
+      type: ADD_CONTACT_API.RESOLVE,
+      body: {status: 'success', data: contact},
+    });
+    expect(newState).toEqual({
+      'auth|123': contact,
+    });
+  });
+  test('Add contact - no account id', () => {
+    const contact = {id: 123};
+    const newState = accountsReducer(undefined, {
+      type: ADD_CONTACT_API.RESOLVE,
+      body: {status: 'success', data: contact},
+    });
+    expect(newState).toEqual({});
+  });
+
   test('Fetch all contacts', () => {
     const contacts = [
       {id: 1},

--- a/src/reducers/contacts.spec.js
+++ b/src/reducers/contacts.spec.js
@@ -1,6 +1,10 @@
-import {contactsReducer} from './contacts';
+import {contactsReducer, accountsReducer} from './contacts';
 
-import {ALL_CONTACTS, ALL_CONTACTS_API} from '../actions/contacts';
+import {
+  ALL_CONTACTS,
+  ALL_CONTACTS_API,
+  GET_MY_CONTACT_API,
+} from '../actions/contacts';
 import {CREATE_RESUME_API} from '../actions/resume';
 
 describe('Contacts state', () => {
@@ -22,6 +26,17 @@ describe('Contacts state', () => {
       4: {id: 4},
     });
   });
+  test('Get my contact', () => {
+    const contact = {id: 123};
+    const newState = contactsReducer(undefined, {
+      type: GET_MY_CONTACT_API.RESOLVE,
+      body: {status: 'success', data: contact},
+    });
+    expect(newState).toEqual({
+      123: {id: 123},
+    });
+  });
+
   test('Replace existing contacts', () => {
     const contacts = [{id: 1}, {id: 2}, {id: 3}, {id: 4}];
     const newState = contactsReducer(
@@ -40,27 +55,37 @@ describe('Contacts state', () => {
       4: {id: 4},
     });
   });
-
-  test('Contacts - Create new resume - request resolved', () => {
-    const newState = contactsReducer(
-      {5: {id: 5}},
-      {
-        type: CREATE_RESUME_API.RESOLVE,
-        body: {
-          data: {
-            other_stuff: 'blah',
-            contact: {
-              id: 5678,
-              other_stuff: 'blah',
-            },
-            id: 1234,
-          },
-        },
-      }
-    );
+});
+describe('accounts state', () => {
+  const initialState = {};
+  test('inital state', () => {
+    const newState = accountsReducer(undefined, {});
+    expect(newState).toEqual(initialState);
+  });
+  test('Fetch all contacts', () => {
+    const contacts = [
+      {id: 1},
+      {id: 2, account_id: 'auth|2'},
+      {id: 3, account_id: 'auth|3'},
+      {id: 4},
+    ];
+    const newState = accountsReducer(undefined, {
+      type: ALL_CONTACTS_API.RESOLVE,
+      body: {status: 'success', data: contacts},
+    });
     expect(newState).toEqual({
-      5: {id: 5},
-      5678: {id: 5678, other_stuff: 'blah'},
+      'auth|2': {id: 2, account_id: 'auth|2'},
+      'auth|3': {id: 3, account_id: 'auth|3'},
+    });
+  });
+  test('Get my contact', () => {
+    const contact = {id: 123, account_id: 'auth|myid'};
+    const newState = accountsReducer(undefined, {
+      type: GET_MY_CONTACT_API.RESOLVE,
+      body: {status: 'success', data: contact},
+    });
+    expect(newState).toEqual({
+      'auth|myid': contact,
     });
   });
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,8 @@
 import {combineReducers} from 'redux';
-import contacts from './contacts';
+import {
+  contactsReducer as contacts,
+  accountsReducer as accounts,
+} from './contacts';
 import {
   experiencesReducer as experiences,
   tagReducer as tags,
@@ -8,6 +11,7 @@ import {
 import resume from './resume';
 
 const rootReducer = combineReducers({
+  accounts,
   contacts,
   experiences,
   resume,


### PR DESCRIPTION
Note this only includes AuthN at the moment, does not lock anything down behind AuthZ
yet. Practically speaking, this means anyone can still see/view anyone
else's profile.

Of course, the AuthZ stuff really needs to be added on the backend first
to actually be meaningful.

Depends on:
https://github.com/baltimorecorps/hippo-backend/pull/41

Changes
* Removes header links except for Contacts
* Added Log In / Log Out buttons on app bar
* Made homepage login card actually work
* Removed extra cards from homepage
* Created Profile creation flow after account signup
* Refactored AddContact form to work outside of a modal as well
* Added Auth0 authentication library for SPA
* Added Auth0 application config
* Set up AddContact form to also send account id
* Added 'GET_MY_CONTACT' action to get authenticated users' contact
* Added an 'accounts' state that indexes contacts by account id