### PR TITLE
AuthZ - include cookies on API requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2258,7 +2258,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-flatten": {
@@ -2513,7 +2513,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2681,7 +2681,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -3123,7 +3123,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3167,7 +3167,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -3329,7 +3329,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
@@ -4092,7 +4092,7 @@
     },
     "clone-deep": {
       "version": "0.2.4",
-      "resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
         "for-own": "^0.1.3",
@@ -4411,7 +4411,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4423,7 +4423,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4497,7 +4497,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
@@ -4997,7 +4997,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -5142,7 +5142,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer2": {
@@ -5652,7 +5652,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
             "esutils": "^2.0.2",
@@ -5669,7 +5669,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7632,7 +7632,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {
@@ -10211,7 +10211,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -10451,7 +10451,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -11129,7 +11129,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
@@ -11278,7 +11278,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -13373,7 +13373,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -13407,7 +13407,7 @@
         },
         "css-select": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "requires": {
             "boolbase": "~1.0.0",
@@ -13754,7 +13754,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -14060,7 +14060,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -14085,7 +14085,7 @@
         },
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -14706,7 +14706,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -14760,7 +14760,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
@@ -14973,7 +14973,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/src/lib/helperFunctions/helpers.js
+++ b/src/lib/helperFunctions/helpers.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactGA from 'react-ga';
+import {makeFetchActions} from 'redux-fetch-wrapper';
 
 const createExternalLink = (content, url, className) => {
   return (
@@ -33,6 +34,27 @@ const createClickTracking = (category, action, label) => {
     action: action,
     label: label,
   });
+};
+
+export const makeApiFetchActions = (
+  action,
+  url,
+  init = null,
+  actions = null,
+  abortController = null,
+  conditional = null
+) => {
+  return async (dispatch) => {
+    init = Object.assign({credentials: 'include'}, init);
+    return await makeFetchActions(
+      action,
+      url,
+      init,
+      actions,
+      abortController,
+      conditional
+    )(dispatch);
+  };
 };
 
 export {createExternalLink, createClickTracking, createALink};

--- a/src/state/contacts.js
+++ b/src/state/contacts.js
@@ -1,5 +1,6 @@
 import {createReducer} from 'redux-starter-kit';
-import {makeFetchActions, fetchActionTypes} from 'redux-fetch-wrapper';
+import {fetchActionTypes} from 'redux-fetch-wrapper';
+import {makeApiFetchActions} from 'lib/helperFunctions/helpers';
 import {makeAuthFetchActions} from 'lib/Auth0/auth0';
 
 import {API_URL} from 'app/constants';
@@ -10,9 +11,12 @@ import {API_URL} from 'app/constants';
 
 export const GET_SESSION_API = fetchActionTypes('GET_SESSION');
 export const getSession = () =>
-  makeFetchActions('GET_SESSION', `${API_URL}/api/session/`, {
-    credentials: 'include',
-  });
+  makeApiFetchActions('GET_SESSION', 
+    `${API_URL}/api/session/`,
+    {
+      credentials: 'include',
+    }
+  );
 
 export const CREATE_SESSION_API = fetchActionTypes('CREATE_SESSION');
 export const createSession = authToken =>
@@ -22,18 +26,22 @@ export const createSession = authToken =>
 
 export const DELETE_SESSION_API = fetchActionTypes('DELETE_SESSION');
 export const deleteSession = () =>
-  makeFetchActions('DELETE_SESSION', `${API_URL}/api/session/`, {
-    method: 'DELETE',
-    credentials: 'include',
-  });
+  makeApiFetchActions(
+    'DELETE_SESSION',
+    `${API_URL}/api/session/`,
+    {
+      method: 'DELETE',
+      credentials: 'include',
+    },
+  );
 
 export const ALL_CONTACTS = 'ALL_CONTACTS';
 export const ALL_CONTACTS_API = fetchActionTypes(ALL_CONTACTS);
 const apiGetAllContacts = () =>
-  makeFetchActions(ALL_CONTACTS, `${API_URL}/api/contacts/`);
+  makeApiFetchActions(ALL_CONTACTS, `${API_URL}/api/contacts/`);
 
 // const apiGetContact = contactId =>
-//   makeFetchActions(CONTACT, `${API_URL}/api/contacts/${contactId}/`);
+//   makeApiFetchActions(CONTACT, `${API_URL}/api/contacts/${contactId}/`);
 
 const apiAddContact = (authToken, contact) =>
   makeAuthFetchActions(authToken, ADD_CONTACT, `${API_URL}/api/contacts/`, {
@@ -45,7 +53,7 @@ const apiAddContact = (authToken, contact) =>
 export const GET_CONTACT = 'GET_CONTACT';
 export const GET_CONTACT_API = fetchActionTypes(GET_CONTACT);
 export const apiGetContact = contactId =>
-  makeFetchActions(GET_CONTACT, `${API_URL}/api/contacts/${contactId}/`);
+  makeApiFetchActions(GET_CONTACT, `${API_URL}/api/contacts/${contactId}/`);
 
 // ## ACTION CREATORS ##
 
@@ -78,7 +86,7 @@ export const addContactSkill = (contactId, skill) =>
       payload,
     });
 
-    const result = await makeFetchActions(
+    const result = await makeApiFetchActions(
       ADD_CONTACT_SKILL,
       `${API_URL}/api/contacts/${contactId}/skills/`,
       {
@@ -106,7 +114,7 @@ export const deleteContactSkill = (contactId, skillId) =>
       },
     });
 
-    const result = await makeFetchActions(
+    const result = await makeApiFetchActions(
       DELETE_CONTACT_SKILL,
       `${API_URL}/api/contacts/${contactId}/skills/`,
       {
@@ -131,7 +139,7 @@ export const updateContact = contact =>
       contact,
     });
 
-    return await makeFetchActions(
+    return await makeApiFetchActions(
       UPDATE_CONTACT,
       `${API_URL}/api/contacts/${contact.id}/`,
       {

--- a/src/state/profile.js
+++ b/src/state/profile.js
@@ -1,5 +1,6 @@
 import {API_URL} from 'app/constants';
-import {makeFetchActions, fetchActionTypes} from 'redux-fetch-wrapper';
+import {makeApiFetchActions} from 'lib/helperFunctions/helpers';
+import {fetchActionTypes} from 'redux-fetch-wrapper';
 import {createReducer} from 'redux-starter-kit';
 
 // Rules for action creators:
@@ -17,12 +18,14 @@ export const addExperience = experience =>
       experience,
     });
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       ADD_EXPERIENCE,
       `${API_URL}/api/contacts/${experience.contact_id}/experiences/`,
       {
         body: JSON.stringify(experience),
         method: 'POST',
+        credentials: 'include',
+
       }
     )(dispatch);
   };
@@ -30,7 +33,7 @@ export const addExperience = experience =>
 export const GET_EXPERIENCE = 'GET_EXPERIENCE';
 export const GET_EXPERIENCE_API = fetchActionTypes(GET_EXPERIENCE);
 export const getExperience = expId =>
-  makeFetchActions(GET_EXPERIENCE, `${API_URL}/api/experiences/${expId}/`);
+  makeApiFetchActions(GET_EXPERIENCE, `${API_URL}/api/experiences/${expId}/`);
 
 export const UPDATE_EXPERIENCE = 'UPDATE_EXPERIENCE';
 export const UPDATE_EXPERIENCE_API = fetchActionTypes(UPDATE_EXPERIENCE);
@@ -41,7 +44,7 @@ export const updateExperience = experience =>
       experience,
     });
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       UPDATE_EXPERIENCE,
       `${API_URL}/api/experiences/${experience.id}/`,
       {
@@ -55,7 +58,7 @@ export const updateExperience = experience =>
 export const REFRESH_EXPERIENCES = 'REFRESH_EXPERIENCES';
 export const REFRESH_EXPERIENCES_API = fetchActionTypes(REFRESH_EXPERIENCES);
 export const refreshExperiences = contactId =>
-  makeFetchActions(
+  makeApiFetchActions(
     REFRESH_EXPERIENCES,
     `${API_URL}/api/contacts/${contactId}/experiences/`
   );
@@ -66,7 +69,7 @@ export const REFRESH_EXPERIENCE_TYPE_API = fetchActionTypes(
 );
 export const refreshExperienceType = (contactId, expType) => {
   expType = expType.toLowerCase();
-  return makeFetchActions(
+  return makeApiFetchActions(
     REFRESH_EXPERIENCE_TYPE,
     `${API_URL}/api/contacts/${contactId}/experiences/?type=${expType}`,
     null,
@@ -88,7 +91,7 @@ export const deleteExperience = experience =>
       experience: experience,
     });
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       DELETE_EXPERIENCE,
       `${API_URL}/api/experiences/${experience.id}/`,
       {
@@ -105,7 +108,7 @@ export const deleteExperience = experience =>
 export const ADD_TAG = 'ADD_TAG';
 export const ADD_TAG_API = fetchActionTypes(ADD_TAG);
 export const addTag = tag =>
-  makeFetchActions(ADD_TAG, `${API_URL}/api/tags/`, {
+  makeApiFetchActions(ADD_TAG, `${API_URL}/api/tags/`, {
     method: 'POST',
     body: JSON.stringify(tag),
   });
@@ -113,7 +116,7 @@ export const addTag = tag =>
 export const REFRESH_TAGS = 'REFRESH_TAGS';
 export const REFRESH_TAGS_API = fetchActionTypes(REFRESH_TAGS);
 export const refreshTags = () =>
-  makeFetchActions(REFRESH_TAGS, `${API_URL}/api/tags/`);
+  makeApiFetchActions(REFRESH_TAGS, `${API_URL}/api/tags/`);
 
 export const ADD_TAG_ITEM = 'ADD_TAG_ITEM';
 export const ADD_TAG_ITEM_API = fetchActionTypes(ADD_TAG_ITEM);
@@ -134,7 +137,7 @@ export const addTagItem = tagItem =>
       tagItem.tag_id = newTagAction.body.data.id;
     }
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       ADD_TAG_ITEM,
       `${API_URL}/api/contacts/${tagItem.contact_id}/tags/`,
       {
@@ -153,7 +156,7 @@ export const updateTagItem = tagItem =>
       tag: tagItem,
     });
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       UPDATE_TAG_ITEM,
       `${API_URL}/api/contacts/${tagItem.contact_id}/tags/${tagItem.tag_id}/`,
       {
@@ -172,7 +175,7 @@ export const deleteTagItem = tagItem =>
       tag: tagItem,
     });
 
-    await makeFetchActions(
+    await makeApiFetchActions(
       DELETE_TAG_ITEM,
       `${API_URL}/api/contacts/${tagItem.contact_id}/tags/${tagItem.tag_id}/`,
       {
@@ -188,7 +191,7 @@ export const REFRESH_TAG_ITEMS_API = fetchActionTypes(REFRESH_TAG_ITEMS);
 export const refreshTagItems = (contactId, tagType) =>
   async function(dispatch) {
     tagType = tagType.toLowerCase();
-    await makeFetchActions(
+    await makeApiFetchActions(
       REFRESH_TAG_ITEMS,
       `${API_URL}/api/contacts/${contactId}/tags/?type=${tagType}`,
       null,

--- a/src/state/programs.js
+++ b/src/state/programs.js
@@ -1,6 +1,8 @@
-import {API_URL} from 'app/constants';
-import {makeFetchActions, fetchActionTypes} from 'redux-fetch-wrapper';
+import {fetchActionTypes} from 'redux-fetch-wrapper';
 import {createReducer} from 'redux-starter-kit';
+
+import {API_URL} from 'app/constants';
+import {makeApiFetchActions} from 'lib/helperFunctions/helpers';
 
 // ## REDUX ACTION TYPES ##
 export const ADD_NEW_PROGRAM = 'ADD_NEW_PROGRAM';
@@ -23,7 +25,7 @@ export const GET_PROGRAM_QUESTIONS_API = fetchActionTypes(
 
 // Creates a new program_contact record, and related response records (if provided)
 const apiAddNewProgram = program =>
-  makeFetchActions(
+  makeApiFetchActions(
     ADD_NEW_PROGRAM,
     `${API_URL}/api/contacts/${program.contact_id}/programs/`,
     {
@@ -34,7 +36,7 @@ const apiAddNewProgram = program =>
 
 // Updates the program member record, including responses to the related questions
 const apiUpdateProgram = program =>
-  makeFetchActions(
+  makeApiFetchActions(
     UPDATE_PROGRAM,
     `${API_URL}/api/contacts/${program.contact_id}/programs/${program.program.id}/`,
     {
@@ -46,14 +48,14 @@ const apiUpdateProgram = program =>
 // Get a list of all of the programs the contact is being considered
 // for and the stage of their application for that program
 export const apiGetAllPrograms = contactId =>
-  makeFetchActions(
+  makeApiFetchActions(
     GET_ALL_PROGRAMS,
     `${API_URL}/api/contacts/${contactId}/programs/`
   );
 
 // Returns a list of all of the questions associated with a particular program
 export const apiGetProgramQuestions = program =>
-  makeFetchActions(
+  makeApiFetchActions(
     GET_PROGRAM_QUESTIONS,
     `${API_URL}/api/contacts/${program.contact_id}/programs/${program.id}/`
   );

--- a/src/state/resume.js
+++ b/src/state/resume.js
@@ -1,6 +1,8 @@
 import {format} from 'date-fns';
 import {API_URL} from 'app/constants';
-import {makeFetchActions, fetchActionTypes} from 'redux-fetch-wrapper';
+
+import {makeApiFetchActions} from 'lib/helperFunctions/helpers';
+import {fetchActionTypes} from 'redux-fetch-wrapper';
 import {createReducer} from 'redux-starter-kit';
 
 export const START_RESUME_CREATION = 'START_RESUME_CREATION';
@@ -30,7 +32,7 @@ export const generateResume = (contactId, resume) =>
       },
     });
 
-    const response = await makeFetchActions(
+    const response = await makeApiFetchActions(
       GENERATE_RESUME,
       `${API_URL}/api/contacts/${contactId}/generate-resume/`,
       {
@@ -68,7 +70,7 @@ export const createResume = (contactId, name) =>
       resume,
     });
 
-    return await makeFetchActions(
+    return await makeApiFetchActions(
       CREATE_RESUME,
       `${API_URL}/api/contacts/${contactId}/resumes/`,
       {
@@ -81,12 +83,12 @@ export const createResume = (contactId, name) =>
 export const REFRESH_RESUME = 'REFRESH_RESUME';
 export const REFRESH_RESUME_API = fetchActionTypes(REFRESH_RESUME);
 export const refreshResume = resumeId =>
-  makeFetchActions(REFRESH_RESUME, `${API_URL}/api/resumes/${resumeId}/`);
+  makeApiFetchActions(REFRESH_RESUME, `${API_URL}/api/resumes/${resumeId}/`);
 
 export const REFRESH_RESUMES = 'REFRESH_RESUMES';
 export const REFRESH_RESUMES_API = fetchActionTypes(REFRESH_RESUMES);
 export const refreshResumes = contactId =>
-  makeFetchActions(
+  makeApiFetchActions(
     REFRESH_RESUMES,
     `${API_URL}/api/contacts/${contactId}/resumes/`,
     null,
@@ -110,7 +112,7 @@ export const updateResume = (resumeId, name) =>
       update,
     });
 
-    return await makeFetchActions(
+    return await makeApiFetchActions(
       UPDATE_RESUME,
       `${API_URL}/api/resumes/${resumeId}/`,
       {
@@ -129,7 +131,7 @@ export const deleteResume = (resumeId, contactId) =>
       resumeId,
     });
 
-    const result = await makeFetchActions(
+    const result = await makeApiFetchActions(
       DELETE_RESUME,
       `${API_URL}/api/resumes/${resumeId}/`,
       {
@@ -158,7 +160,7 @@ export const createResumeSection = section =>
       throw new Error('invalid section given to createResumeSection!');
     }
 
-    return await makeFetchActions(
+    return await makeApiFetchActions(
       CREATE_SECTION,
       `${API_URL}/api/resumes/${section.resume_id}/sections/`,
       {
@@ -171,7 +173,7 @@ export const createResumeSection = section =>
 export const REFRESH_SECTION = 'REFRESH_SECTION';
 export const REFRESH_SECTION_API = fetchActionTypes(REFRESH_SECTION);
 export const refreshResumeSection = (resumeId, sectionId) =>
-  makeFetchActions(
+  makeApiFetchActions(
     REFRESH_SECTION,
     `${API_URL}/api/resumes/${resumeId}/sections/${sectionId}/`
   );
@@ -179,7 +181,7 @@ export const refreshResumeSection = (resumeId, sectionId) =>
 export const UPDATE_SECTION = 'UPDATE_SECTION';
 export const UPDATE_SECTION_API = fetchActionTypes(UPDATE_SECTION);
 export const updateResumeSection = section =>
-  makeFetchActions(
+  makeApiFetchActions(
     UPDATE_SECTION,
     `${API_URL}/api/resumes/${section.resume_id}/sections/${section.id}/`,
     {
@@ -214,7 +216,7 @@ export const DELETE_SECTION = 'DELETE_SECTION';
 export const DELETE_SECTION_API = fetchActionTypes(DELETE_SECTION);
 export const deleteResumeSection = (resumeId, sectionId) =>
   async function(dispatch) {
-    const result = await makeFetchActions(
+    const result = await makeApiFetchActions(
       DELETE_SECTION,
       `${API_URL}/api/resumes/${resumeId}/sections/${sectionId}/`,
       {


### PR DESCRIPTION
Includes cookies on all API requests. This is necessary because the AuthZ changes will add a login requirement to nearly all of the API endpoints we use.

This should be merged before the AuthZ backend changes for a smooth rollout, as including credentials on existing API requests will not cause any problems.